### PR TITLE
Update to v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [v1.2.3] - 2025-12-13
+
+### Updated Dependencies
+
+- **Runtime Update**: Updated the base runtime from org.kde.Platform version '6.8' to version '6.9'. This transition was necessary because version 6.8 has reached its End-of-Life (EOL).
+
+- **Base App Update**: Updated the base application from io.qt.qtwebengine.BaseApp version '6.8' to version '6.9' to maintain compatibility with the new platform runtime.
+
+---
+
+## [v1.2.2] - 2025-10-31
+
+### Bug Fixes and Improvements
+
+- **Custom Context Menu Implementation**: Subclassed QWebEnginePage and created a fully functional custom context menu with enhanced functionality and improved user experience.
+
+- **Consistent Profile Linking**: Ensured links opened from a tab share the same profile type as the calling tab, maintaining profile consistency across navigation and new tab operations.
+
+- **Code Polishes and Improvements**: Performed various code optimizations, refactoring, and maintenance improvements for better performance, stability, and maintainability.
+
+---
+
 ## [v1.2.1] - 2025-07-23
 
 ### Bug Fixes and Improvements

--- a/io.github.alamahant.Jasmine.yml
+++ b/io.github.alamahant.Jasmine.yml
@@ -1,8 +1,8 @@
 app-id: io.github.alamahant.Jasmine
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.8'
+base-version: '6.9'
 runtime: org.kde.Platform
-runtime-version: '6.8'
+runtime-version: '6.9'
 sdk: org.kde.Sdk
 command: Jasmine
 finish-args:
@@ -21,8 +21,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/Jasmine.git
-        tag: v1.2.1
-
+        tag: v1.2.3
+        commit: 4c59ecfb9f15bd160bf0c5fedaf4c5d7e6e50637
 
 
 


### PR DESCRIPTION
## [v1.2.3] - 2025-12-13

### Updated Dependencies

- **Runtime Update**: Updated the base runtime from org.kde.Platform version '6.8' to version '6.9'. This transition was necessary because version 6.8 has reached its End-of-Life (EOL).

- **Base App Update**: Updated the base application from io.qt.qtwebengine.BaseApp version '6.8' to version '6.9' to maintain compatibility with the new platform runtime.
