### PR TITLE
update to v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [v1.2.5] - 2026-03-05
+
+### New Features
+
+- **NVIDIA GPU Workaround**: Added "Disable GPU Acceleration" option in Tools menu for users experiencing graphical issues. When enabled, this setting applies the `--disable-gpu` flag to QtWebEngine, resolving crashes and rendering problems on NVIDIA systems. A restart notification ensures users understand when changes take effect.
+
+### Dependency Updates
+
+- **Flatpak Runtime**: Updated base application to `io.qt.qtwebengine.BaseApp` version 6.10
+- **KDE Platform**: Updated runtime to `org.kde.Platform` version 6.10
+
+---
+
 ## [v1.2.4] - 2025-12-21
 
 ### Enhancements

--- a/io.github.alamahant.Jasmine.yml
+++ b/io.github.alamahant.Jasmine.yml
@@ -1,8 +1,8 @@
 app-id: io.github.alamahant.Jasmine
 base: io.qt.qtwebengine.BaseApp
-base-version: '6.9'
+base-version: '6.10'
 runtime: org.kde.Platform
-runtime-version: '6.9'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: Jasmine
 finish-args:
@@ -21,5 +21,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/Jasmine.git
-        tag: v1.2.4
-        commit: 86cf49c15304801113a73a85301b28dc3f16148e
+        tag: v1.2.5
+        commit: 497c59cf0aab801ec72aa39e8bae84cb7e7f30f4


### PR DESCRIPTION

## [v1.2.5] - 2026-03-05

### New Features

- **NVIDIA GPU Workaround**: Added "Disable GPU Acceleration" option in Tools menu for users experiencing graphical issues. When enabled, this setting applies the `--disable-gpu` flag to QtWebEngine, resolving crashes and rendering problems on NVIDIA systems. A restart notification ensures users understand when changes take effect.

### Dependency Updates

- **Flatpak Runtime**: Updated base application to `io.qt.qtwebengine.BaseApp` version 6.10
- **KDE Platform**: Updated runtime to `org.kde.Platform` version 6.10

---
