### PR TITLE
Improve cleanup commands

### DIFF
--- a/io.github.alamahant.Jasmine.yml
+++ b/io.github.alamahant.Jasmine.yml
@@ -13,6 +13,13 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --filesystem=xdg-documents/Jasmine:create
+cleanup:
+  - /include
+  - /lib/*/cmake
+  - /lib/cmake
+  - /mkspecs
+cleanup-commands:
+  - /app/cleanup-BaseApp.sh
 modules:
   - name: jasmine
     buildsystem: cmake-ninja


### PR DESCRIPTION
- Improve the cleanup command to reduce the Flatpak size.
- Apply the cleanup-Baseapp.sh script to remove development-related files.