### PR TITLE
update to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,68 @@
 # Changelog
 
+## [v1.3.0] - 2026-05-22
+
+### New Features: Podcast Manager
+
+**Podcast Tab:**
+- Complete podcast manager with grid-based cards for subscribed shows
+- Browse podcasts via iTunes Search API (search by name, category, or author)
+- Subscribe directly using RSS feed URL (works with any podcast host)
+- Import/Export podcast subscriptions using OPML format (standard for podcast apps)
+- Automatic episode fetching and parsing from RSS feeds
+- Download and cache podcast artwork locally
+- Episode list with play/stop controls, duration, and publish date
+- Purple bold highlight for currently playing episode
+- Manual icon generation for podcasts without artwork
+- Play episodes using existing AdFreePlayerDialog
+
+**Podcast Details Panel:**
+- Show artwork, title, author, category, feed URL, website link
+- Episode count and last updated timestamp
+- Collapsible comments section with auto-save
+- Refresh individual podcast feed
+- Unsubscribe button
+
+**Podcast Card:**
+- 200x200 square card with artwork, title, author, episode count
+- Unsubscribe button on card
+- Purple playing indicator when any episode is playing
+
+**Podcast Search Dialog:**
+- Search by name, category, or author via iTunes API
+- Subscribe by direct RSS feed URL
+- Results table with podcast, category, author
+- Preview section with details before subscribing
+- Non-modal dialog (stays open for multiple subscriptions)
+
+**Import/Export:**
+- Export podcast subscriptions to OPML file for backup or migration
+- Import subscriptions from OPML file
+- Duplicate detection prevents double subscriptions
+
+**Technical Improvements:**
+- RSS feed parser using QXmlStreamReader
+- Background episode fetching doesn't block UI
+- Automatic artwork download and caching
+- Persistent storage using QDataStream
+- Dark theme support for all podcast dialogs
+
+### Radio & IPTV Enhancements:
+- Added "Refresh All Podcasts" action in Tools menu
+- Fixed episode highlight persistence when switching tabs
+- Added generate icon button with warning message for podcasts
+- Improved list widget styling for dark theme
+
+### Bug Fixes:
+- Fixed episode highlight disappearing when switching podcasts
+- Fixed artwork not displaying for imported podcasts
+- Fixed URL subscription parsing for various feed formats
+- Fixed duplicate detection in OPML import
+
+---
+
+**Full changelog:** [v1.2.9] - [v1.3.0]
+
 ## [v1.2.9] - 2026-05-21
 
 ### New Features: Radio Stations & IPTV

--- a/io.github.alamahant.Jasmine.yml
+++ b/io.github.alamahant.Jasmine.yml
@@ -29,9 +29,14 @@ modules:
     sources:
       - type: file
         url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux
+        only-arches: [x86_64]
         sha256: c2b0189f581fe4a2ddd41954f1bcb7d327db04b07ed0dea97e4f1b3e09b5dd8e
         dest-filename: yt-dlp
-
+      - type: file
+        url: https://github.com/yt-dlp/yt-dlp/releases/download/2026.03.17/yt-dlp_linux_aarch64
+        only-arches: [aarch64]
+        sha256: 6bfa19736181da9e2e066f9c767da2f24fdcc5e148fa5034d1feb09132f89ad5
+        dest-filename: yt-dlp
   - name: jasmine
     buildsystem: cmake-ninja
     config-opts:
@@ -40,5 +45,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/Jasmine.git
-        tag: v1.2.9
-        commit: 4235b5057ee7a27962b825120cda2f829f54e541
+        tag: v1.3.0
+        commit: 433622abed89a501d3ac3def5f17d3bc76b4983b


### PR DESCRIPTION
## [v1.3.0] - 2026-05-22

### New Features: Podcast Manager

**Podcast Tab:**
- Complete podcast manager with grid-based cards for subscribed shows
- Browse podcasts via iTunes Search API (search by name, category, or author)
- Subscribe directly using RSS feed URL (works with any podcast host)
- Import/Export podcast subscriptions using OPML format (standard for podcast apps)
- Automatic episode fetching and parsing from RSS feeds
- Download and cache podcast artwork locally
- Episode list with play/stop controls, duration, and publish date
- Purple bold highlight for currently playing episode
- Manual icon generation for podcasts without artwork
- Play episodes using existing AdFreePlayerDialog

**Podcast Details Panel:**
- Show artwork, title, author, category, feed URL, website link
- Episode count and last updated timestamp
- Collapsible comments section with auto-save
- Refresh individual podcast feed
- Unsubscribe button

**Podcast Card:**
- 200x200 square card with artwork, title, author, episode count
- Unsubscribe button on card
- Purple playing indicator when any episode is playing

**Podcast Search Dialog:**
- Search by name, category, or author via iTunes API
- Subscribe by direct RSS feed URL
- Results table with podcast, category, author
- Preview section with details before subscribing
- Non-modal dialog (stays open for multiple subscriptions)

**Import/Export:**
- Export podcast subscriptions to OPML file for backup or migration
- Import subscriptions from OPML file
- Duplicate detection prevents double subscriptions

**Technical Improvements:**
- RSS feed parser using QXmlStreamReader
- Background episode fetching doesn't block UI
- Automatic artwork download and caching
- Persistent storage using QDataStream
- Dark theme support for all podcast dialogs

### Radio & IPTV Enhancements:
- Added "Refresh All Podcasts" action in Tools menu
- Fixed episode highlight persistence when switching tabs
- Added generate icon button with warning message for podcasts
- Improved list widget styling for dark theme

### Bug Fixes:
- Fixed episode highlight disappearing when switching podcasts
- Fixed artwork not displaying for imported podcasts
- Fixed URL subscription parsing for various feed formats
- Fixed duplicate detection in OPML import

---