### PR TITLE
emergency update to fix critical display bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v1.3.1] - 2026-05-22
+
+### Fixed
+- Emergency update to fix critical display bug: Removed separator lines appearing above podcast episode items.
+
+---
+
 ## [v1.3.0] - 2026-05-22
 
 ### New Features: Podcast Manager

--- a/io.github.alamahant.Jasmine.yml
+++ b/io.github.alamahant.Jasmine.yml
@@ -46,4 +46,4 @@ modules:
       - type: git
         url: https://github.com/alamahant/Jasmine.git
         tag: v1.3.1
-        commit: ebbbe60c5e5623f6172a4ad5f30e3559ed5c37d7
+        commit: 1d5ec465131ab0ab212f7b9f6003a7245aa64bac

--- a/io.github.alamahant.Jasmine.yml
+++ b/io.github.alamahant.Jasmine.yml
@@ -45,5 +45,5 @@ modules:
     sources:
       - type: git
         url: https://github.com/alamahant/Jasmine.git
-        tag: v1.3.0
-        commit: 433622abed89a501d3ac3def5f17d3bc76b4983b
+        tag: v1.3.1
+        commit: ebbbe60c5e5623f6172a4ad5f30e3559ed5c37d7


### PR DESCRIPTION
## [v1.3.1] - 2026-05-22

### Fixed
- Emergency update to fix critical display bug: Removed separator lines appearing above podcast episode items.

---